### PR TITLE
Clean up UserData Sample Commands

### DIFF
--- a/rhinocommon/cs/SampleCsUserData/Commands/SampleCsAddUserData.cs
+++ b/rhinocommon/cs/SampleCsUserData/Commands/SampleCsAddUserData.cs
@@ -36,7 +36,9 @@ namespace SampleCsUserData.Commands
           Notes = gs.StringResult()
         };
 
-        obj.Attributes.UserData.Add(ud);
+        var attributes = obj.Attributes.Duplicate();
+        attributes.UserData.Add(ud);
+        doc.Objects.ModifyAttributes(objref, attributes, false);
       }
       else
       {

--- a/rhinocommon/cs/SampleCsUserData/Commands/SampleCsModifyUserData.cs
+++ b/rhinocommon/cs/SampleCsUserData/Commands/SampleCsModifyUserData.cs
@@ -26,7 +26,8 @@ namespace SampleCsUserData.Commands
       if (null == obj)
         return Result.Failure;
 
-      var ud = obj.Attributes.UserData.Find(typeof(SampleCsUserDataObject)) as SampleCsUserDataObject;
+      var attributes = obj.Attributes.Duplicate();
+      var ud = attributes.UserData.Find(typeof(SampleCsUserDataObject)) as SampleCsUserDataObject;
       if (null != ud)
       {
         var gs = new GetString();
@@ -36,6 +37,9 @@ namespace SampleCsUserData.Commands
           return gs.CommandResult();
 
         ud.Notes = gs.StringResult();
+
+        attributes.UserData.Add(ud);
+        doc.Objects.ModifyAttributes(objref, attributes, false);
       }
 
       return Result.Success;

--- a/rhinocommon/cs/SampleCsUserData/Commands/SampleCsRemoveUserData.cs
+++ b/rhinocommon/cs/SampleCsUserData/Commands/SampleCsRemoveUserData.cs
@@ -25,9 +25,13 @@ namespace SampleCsUserData.Commands
       if (null == obj)
         return Result.Failure;
 
+      var attributes = obj.Attributes.Duplicate();
       var ud = obj.Attributes.UserData.Find(typeof(SampleCsUserDataObject)) as SampleCsUserDataObject;
       if (null != ud)
-        obj.Attributes.UserData.Remove(ud);
+      {
+        attributes.UserData.Remove(ud);
+        doc.Objects.ModifyAttributes(objref, attributes, false);
+      }
 
       return Result.Success;
     }


### PR DESCRIPTION
Clean up fixes to UserData example per the discussion on discourse: [Attribute Changes Don’t Apply To Nested Blocks](https://discourse.mcneel.com/t/attribute-changes-dont-apply-to-nested-blocks/160425/5)

Without calling `ModifyAttributes` after a change to the userdata, the `RhinoDoc.ModifyObjectAttributes` Event does get triggered.