### PR TITLE
New RhinoCommon sample command SampleCsCachedTextureCoordinates

### DIFF
--- a/rhinocommon/cs/SampleCsCommands/SampleCsCachedTextureCoordinates.cs
+++ b/rhinocommon/cs/SampleCsCommands/SampleCsCachedTextureCoordinates.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using Rhino;
+using Rhino.Commands;
+using Rhino.DocObjects;
+using Rhino.Geometry;
+using Rhino.Input.Custom;
+using Rhino.Render;
+
+namespace SampleCsCommands
+{
+  /// <summary>
+  /// This command demonstrates how to set up cached texture coordinates based on the material texture channels.
+  /// </summary>
+  public class SampleCsCachedTextureCoordinates : Command
+  {
+    public override string EnglishName => "SampleCsCachedTextureCoordinates";
+
+    protected override Result RunCommand(RhinoDoc doc, RunMode mode)
+    {
+      var go = new GetObject();
+      go.SetCommandPrompt("Select objects");
+      go.GetMultiple(1, 0);
+      if (go.CommandResult() != Result.Success)
+        return go.CommandResult();
+
+      foreach (var rhinoObjectRef in go.Objects())
+      {
+        RhinoObject rhinoObject = rhinoObjectRef.Object();
+        if (null == rhinoObject)
+          continue;
+
+        // Get the object material, this material is used where subobject material is not defined
+        var objectMaterial = rhinoObject.GetMaterial(true);
+
+        // Get the render meshes from the object
+        var meshes = rhinoObject.GetMeshes(MeshType.Render);
+
+        // If there are no render meshes, create them and get them again
+        if (meshes == null || meshes.Length == 0)
+        {
+          rhinoObject.CreateMeshes(MeshType.Render, rhinoObject.GetRenderMeshParameters(), false);
+          meshes = rhinoObject.GetMeshes(MeshType.Render);
+          if (meshes == null || meshes.Length == 0)
+          {
+            continue;
+          }
+        }
+
+        RhinoApp.WriteLine($"Object {rhinoObject.Id} with {meshes.Length} meshes");
+
+        // Iterate through the meshes, each polysurface face has a corresponding mesh
+        for (int mi = 0; mi < meshes.Length; mi++)
+        {
+          var mesh = meshes[mi];
+          if (null == mesh)
+            continue;
+
+          // Figure out which material to use for this mesh
+          var meshMaterial = objectMaterial;
+          if (rhinoObject.HasSubobjectMaterials)
+          {
+            // If this object has subobject materials, figure out what is the component type of its subobject
+            ComponentIndexType ciSubMaterialComponentType = ComponentIndexType.InvalidType;
+            if (rhinoObject.ObjectType == ObjectType.SubD)
+              ciSubMaterialComponentType = ComponentIndexType.SubdFace;
+            else if (rhinoObject.ObjectType == ObjectType.Brep)
+              ciSubMaterialComponentType = ComponentIndexType.BrepFace;
+            else if (rhinoObject.ObjectType == ObjectType.Extrusion)
+              ciSubMaterialComponentType = ComponentIndexType.BrepFace;
+
+            // Ask if there is a subobject material for the current subobject
+            ComponentIndex ci = new ComponentIndex(ciSubMaterialComponentType, mi);
+            var subObjectMaterial = rhinoObject.GetMaterial(ci);
+            if (subObjectMaterial != null)
+              meshMaterial = subObjectMaterial;
+          }
+
+          RhinoApp.WriteLine($"  Mesh {mi} material {meshMaterial.Id}");  
+
+          // Set up cached texture coordinates based on the material texture channels
+          mesh.SetCachedTextureCoordinatesFromMaterial(rhinoObject, meshMaterial);
+
+          // Get all the textures used by the material
+          var textures = meshMaterial.GetTextures();
+          foreach (var texture in textures)
+          {
+            if (texture == null)
+              continue;
+
+            // Get the cached texture coordinates for this texture
+            CachedTextureCoordinates cachedTCs = mesh.GetCachedTextureCoordinates(rhinoObject, texture);
+            if (cachedTCs != null && cachedTCs.Count == mesh.Vertices.Count)
+            {
+              RhinoApp.Write($"    Cached texture coordinates for {texture.TextureType} texture. ");
+              if (texture.WcsProjected)
+                RhinoApp.Write($"Wcs projection used.");
+              else if (texture.WcsBoxProjected)
+                RhinoApp.Write($"Wcs box projection used.");
+              else if (texture.MappingChannelId > 0)
+                RhinoApp.Write($"Mapping channel {texture.MappingChannelId} used.");
+              RhinoApp.Write($"\n");
+            }
+          }
+        }
+      }
+      return Result.Success;
+    }
+  }
+}

--- a/rhinocommon/cs/SampleCsCommands/SampleCsCommands.csproj
+++ b/rhinocommon/cs/SampleCsCommands/SampleCsCommands.csproj
@@ -69,6 +69,7 @@
     <Compile Include="SampleCsApplyCrv.cs" />
     <Compile Include="SampleCsArc.cs" />
     <Compile Include="SampleCsBooleanDifference4.cs" />
+    <Compile Include="SampleCsCachedTextureCoordinates.cs" />
     <Compile Include="SampleCsCreateBooleanRegions.cs" />
     <Compile Include="SampleCsCreateUVCurve.cs" />
     <Compile Include="SampleCsAddAlignedDimension.cs" />


### PR DESCRIPTION
New RhinoCommon sample command SampleCsCachedTextureCoordinates to demonstrate how to set up cached texture coordinates based on the material texture channels.
Cite #RH-81176