### PR TITLE
Adds reverse tabIndex direction when using shift-tab

### DIFF
--- a/rhinocommon/cs/SampleCsWinForms/Forms/SampleCsModelessTabFix.cs
+++ b/rhinocommon/cs/SampleCsWinForms/Forms/SampleCsModelessTabFix.cs
@@ -52,7 +52,7 @@ namespace SampleCsWinForms.Forms
       m_controls = new SortedDictionary<int, Control>();
       if (LoadControlsTabIndices(form.Controls))
       {
-        m_form.KeyPress += OnKeyPress;
+        m_form.KeyDown += OnKeyDown;
         m_enumerator = m_controls.GetEnumerator();
       }
     }
@@ -143,13 +143,53 @@ namespace SampleCsWinForms.Forms
     }
 
     /// <summary>
-    /// Tab key pressed event handler
+    /// Returns the previous control based on TabIndex, wrapping to the last control
+    /// if at the beginning of the sequence.
     /// </summary>
-    private void OnKeyPress(object sender, KeyPressEventArgs e)
+    private Control PreviousControl
     {
-      if (e.KeyChar == '\t')
+      get
       {
-        NextControl.Focus();
+        Control ctrl = GetActiveControl();
+        if (m_enumerator.Current.Value != ctrl)
+          InitializeControlEnumerator(ctrl);
+
+        int currentKey = m_enumerator.Current.Key;
+
+        int? previousKey = null;
+        foreach (var kvp in m_controls)
+        {
+          if (kvp.Key == currentKey)
+            break;
+          previousKey = kvp.Key;
+        }
+
+        if (!previousKey.HasValue)
+        {
+          foreach (var kvp in m_controls)
+          {
+            previousKey = kvp.Key;
+          }
+        }
+
+        return m_controls[previousKey.Value];
+      }
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+    {
+      if (e.KeyCode == Keys.Tab)
+      {
+        e.Handled = true;
+
+        if (e.Shift)
+        {
+          PreviousControl.Focus();
+        }
+        else
+        {
+          NextControl.Focus();
+        }
       }
     }
   }


### PR DESCRIPTION
Just for fun, I saw it and thought I'd it implement it.

Changes:
- uses `OnKeyDown` instead of `OnKeyPress` so can use `e.KeyCode == Keys.Tab` and `e.Shift` (can revert to using e.KeyChar if that's preferred).
- Used `NextControl` as base for `PreviousControl`
- `PreviousControl` returns previous control by iterating through controls, storing reference to control in `previousKey`, until it breaks at current control
- Handles if If current control is first in dictionary, will iterate through entire dict to get the last control.

To test:
- run `SampleCsModelessTabForm` command, check that tab press increments tab index, check that tab-shift reverses tab index direction

Tried to keep consistent code style with existing. Also not sure what your contributions policy is (no worries if you don't accept PRs!)