### PR TITLE
RH-95837: Soften SubNodeControl note (no separate bug planned)

### DIFF
--- a/rhinocommon/cs/SampleCsRdk/CustomMaterialUserInterfaceSection.Designer.cs
+++ b/rhinocommon/cs/SampleCsRdk/CustomMaterialUserInterfaceSection.Designer.cs
@@ -1,9 +1,9 @@
 ﻿using System.Windows.Forms;
 using RhinoWindows.Forms;
 
-// NOTE: RhinoWindows.Forms.Controls.Render.SubNodeControl is obsolete in Rhino 9 and
-// has no supported replacement yet. The control is disabled (commented out) here until
-// a replacement is available; tracked as a separate bug (RDK / Max). See RH-95837.
+// NOTE: RhinoWindows.Forms.Controls.Render.SubNodeControl is obsolete in Rhino 9 with
+// no supported replacement. The control is disabled (commented out) here until a
+// replacement is available.
 
 namespace SampleCsRdk
 {

--- a/rhinocommon/cs/SampleCsRdk/TestCustomMeshProvider.cs
+++ b/rhinocommon/cs/SampleCsRdk/TestCustomMeshProvider.cs
@@ -47,15 +47,14 @@ namespace SampleCsRdk
         ? new Sphere(new Point3d(0.0, 0.0, 0.0), 10.0)
         : SphereFromObject(obj);
 
-      // Always supply a valid material for the instance. In principle, when the
-      // caller sets the ReturnNullForStandardMaterial flag we could return a null
-      // material to mean "use the object's standard material". However, honoring
-      // that flag currently leaves the custom render meshes unshaded (wireframe)
-      // in shaded display - both the per-object and non-object CRM display paths
-      // fail to substitute a material for the null. Until that is fixed in the
-      // core (see RH-96417), always resolve and supply a material here so the
-      // sample renders correctly.
-      RenderMaterial material = obj?.RenderMaterial ?? RenderMaterial.CreateBasicMaterial(Material.DefaultMaterial, doc);
+      // Honor the ReturnNullForStandardMaterial flag. When the caller sets it
+      // (e.g. shaded display), return a null material to indicate that the
+      // object's standard material should be used - the display resolves it.
+      // Only supply our own material when the flag is clear (e.g. production
+      // rendering). Requires the RH-96417 fix, present in Rhino 9.
+      RenderMaterial material = null;
+      if (!flags.HasFlag(Flags.ReturnNullForStandardMaterial))
+        material = obj?.RenderMaterial ?? RenderMaterial.CreateBasicMaterial(Material.DefaultMaterial, doc);
 
       // Fold the incoming hash together with this sphere so the cached meshes
       // are rebuilt when an upstream provider or the source geometry changes.


### PR DESCRIPTION
SubNodeControl stays disabled (obsolete in Rhino 9, no replacement); drop the "tracked as a separate bug (RDK / Max)" wording since that work is not planned.